### PR TITLE
add uv as installer

### DIFF
--- a/scvi_colab/_core.py
+++ b/scvi_colab/_core.py
@@ -50,11 +50,18 @@ def install(
     if branch is not None and version is not None:
         raise ValueError("One of branch or version must be None.")
 
+    pip_command = "uv pip install --system "
+    try:
+        subprocess.call(["uv", '--version'])
+    except FileNotFoundError:
+        logger.debug('uv not installed, fallback to pip')
+        pip_command = "pip install "
+
     logger.info("Installing scvi-tools.")
 
     if not unfixed:
-        _run_command("pip install scanpy")
-        _run_command("pip install pynndescent")
+        _run_command( pip_command + "scanpy")
+        _run_command( pip_command + "pynndescent")
         # caching issues in colab causing pynndescent import to fail
         success = False
         while not success:
@@ -66,14 +73,14 @@ def install(
                 success = False
 
     if branch is None:
-        command = "pip install --quiet scvi-tools[tutorials]"
+        command = pip_command + " --quiet scvi-tools[tutorials]"
         if version is not None:
             command += f"=={version}"
     else:
         repo = (
             f"https://github.com/scverse/scvi-tools@{branch}#egg=scvi-tools[tutorials]"
         )
-        command = f"pip install --quiet git+{repo}"
+        command = pip_command + f" --quiet git+{repo}"
     _run_command(command)
 
     logger.info("Install successful. Testing import.")
@@ -84,7 +91,6 @@ def install(
         logger.warning(
             "Import unsuccessful. Try restarting (not resetting) the session and running again."
         )
-
 
 def _run_command(command: str):
 


### PR DESCRIPTION
The purpose of this PR is to add uv support to the install() function. in my test on colab, uv pip install --system is much faster than pip install. Although uv is installed in all colab instances I ran recently, a try clause is added to test whether uv is installed in the instance.